### PR TITLE
Always respect max width, even when cells are arranged vertically

### DIFF
--- a/src/Cell.js
+++ b/src/Cell.js
@@ -9,11 +9,12 @@ import React from 'react'
 class Cell extends React.Component {
 
   render () {
-    const { inline, width, padding, children } = this.props
+    const { inline, width, padding, children, max } = this.props
     const style = {
       boxSizing: 'border-box',
       display: inline ? 'inline-block' : 'block',
       width: inline ? `${width * 100}%` : '100%',
+      maxWidth: `${max}px`,
       verticalAlign: 'top',
       paddingLeft: padding,
       paddingRight: padding,


### PR DESCRIPTION
I'm not sure whether this was your original intent or not; but for my use case, I don't want cells to ever expand beyond max. This makes treatment of max width consistent between collapsed multi-cell rows and single-cell rows (i.e. it is respected in both cases).
